### PR TITLE
chore: update copyright year to 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Like this project? Follow the repository on [GitHub](https://github.com/tedilabs
 
 Provided under the terms of the [Apache License](LICENSE).
 
-Copyright © 2024, [Byungjin Park](https://www.posquit0.com).
+Copyright © 2024-2025, [Byungjin Park](https://www.posquit0.com).


### PR DESCRIPTION
## Summary
- Updated copyright year from "Copyright © 2024" to "Copyright © 2024-2025" in README.md

## Test plan
- [x] Verify copyright notice is updated correctly
- [x] Ensure no other content was modified