### PR TITLE
chore: remove common labels from labels.yaml

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,43 +1,10 @@
 # Warning
-- color: "ee0701"
-  description: "Categorize bug reports."
-  name: ":warning: bug"
-- color: "ee0701"
-  description: "Categorize vulnerability reports."
-  name: ":warning: vulnerability"
 
 # Highlight
-- color: "0e8a16"
-  description: "Good for newcomers."
-  name: ":fire: good first issue"
-- color: "0e8a16"
-  description: "Extra attention is needed."
-  name: ":fire: help wanted"
 
 # Cancel
-- color: "b60205"
-  description: "This issue or pull request already exists."
-  name: ":pray: duplicate"
-- color: "b60205"
-  description: "This will not be worked on."
-  name: ":pray: wontfix"
 
 # Size
-- color: "cfd3d7"
-  description: "Extra Small size issue or PR."
-  name: "size/XS"
-- color: "cfd3d7"
-  description: "Small size issue or PR."
-  name: "size/S"
-- color: "cfd3d7"
-  description: "Medium size issue or PR."
-  name: "size/M"
-- color: "cfd3d7"
-  description: "Large size issue or PR."
-  name: "size/L"
-- color: "cfd3d7"
-  description: "Extra Large size issue or PR."
-  name: "size/XL"
 
 # Modules
 - color: "fbca04"


### PR DESCRIPTION
This PR removes labels that are defined in `.github/labels.common.yaml` from the repository-specific `.github/labels.yaml` file.

The common labels are now managed centrally and should not be duplicated in individual repository label files.

**Changes:**
- Removed labels that are already defined in `.github/labels.common.yaml`
- Kept only repository-specific labels in `.github/labels.yaml`
- Maintained trailing newline at the end of the file

This is part of the effort to centralize common label management across the organization.